### PR TITLE
Fix ID conflict with fmt library

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -30,7 +30,7 @@ LOCAL_MODULE := conditional-dependencies-test
 LOCAL_SRC_FILES += src/test.cpp src/another_testing_translationUnit.cpp
 LOCAL_SHARED_LIBRARIES += modloader
 LOCAL_LDLIBS += -llog
-LOCAL_CFLAGS += -DVERSION='"0.1.0"' -DID='"conditional-dependencies"' -I'./shared' -I'./extern'
+LOCAL_CFLAGS += -DVERSION='"0.1.0"' -DMOD_ID='"conditional-dependencies"' -I'./shared' -I'./extern'
 LOCAL_CPPFLAGS += -std=c++2a -frtti
 LOCAL_C_INCLUDES += ./include ./src
 include $(BUILD_SHARED_LIBRARY)

--- a/shared/logging.hpp
+++ b/shared/logging.hpp
@@ -3,9 +3,9 @@
 #include <android/log.h>
 
 #ifndef CONDDEPS_LOG_WARN
-#define CONDDEPS_LOG_WARN(...) __android_log_print(ANDROID_LOG_WARN, "QuestHook[" ID "|" VERSION "]", __VA_ARGS__)
+#define CONDDEPS_LOG_WARN(...) __android_log_print(ANDROID_LOG_WARN, "QuestHook[" MOD_ID "|" VERSION "]", __VA_ARGS__)
 #endif
 
 #ifndef CONDDEPS_LOG_INFO
-#define CONDDEPS_LOG_INFO(...) __android_log_print(ANDROID_LOG_WARN, "QuestHook[" ID "|" VERSION "]", __VA_ARGS__)
+#define CONDDEPS_LOG_INFO(...) __android_log_print(ANDROID_LOG_WARN, "QuestHook[" MOD_ID "|" VERSION "]", __VA_ARGS__)
 #endif


### PR DESCRIPTION
ID is an identifier used by fmt, using this for logging causes issues,

by making it use MOD_ID instead this should be fixed